### PR TITLE
Remove extra derefs

### DIFF
--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -25,7 +25,7 @@ class BaseDict(dict):
 
     def __getitem__(self, key, *args, **kwargs):
         value = super(BaseDict, self).__getitem__(key)
-
+        
         EmbeddedDocument = _import_class('EmbeddedDocument')
         if isinstance(value, EmbeddedDocument) and value._instance is None:
             value._instance = self._instance
@@ -111,6 +111,9 @@ class BaseList(list):
 
     def __getitem__(self, key, *args, **kwargs):
         value = super(BaseList, self).__getitem__(key)
+
+        if 'DocumentProxy' in str(type(value)):
+            return value
 
         EmbeddedDocument = _import_class('EmbeddedDocument')
         if isinstance(value, EmbeddedDocument) and value._instance is None:

--- a/mongoengine/queryset/visitor.py
+++ b/mongoengine/queryset/visitor.py
@@ -56,7 +56,14 @@ class SimplificationVisitor(QNodeVisitor):
                 raise DuplicateQueryConditionsError()
 
             query_ops.update(ops)
+            
+            # Convert DocumentProxy to ids.
+            for op in ops:
+                if 'DocumentProxy' in str(type(query[op])):
+                    query[op] = query[op].id
+            
             combined_query.update(copy.deepcopy(query))
+            
         return combined_query
 
 


### PR DESCRIPTION
Removing some more instances.

If isinstance or deepcopy can be made to work with DocumentProxy that avoid a lot of extra calls.