### PR TITLE
Add new index for fetching historical data in reports 

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -894,6 +894,7 @@ class BaseDocument(object):
             indexes.append({'fields': [('history_date', -1)]})
             indexes.append({'fields': [('history_date', -1), ('_auto_id_0', 1)]})
             indexes.append({'fields': [('_auto_id_0', 1), ('history_date', -1)]})
+            indexes.append({'fields': [('history_date', -1), ('_auto_id_0', -1)]})
 
         return indexes
         

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -893,7 +893,7 @@ class BaseDocument(object):
             # _rippling_process_index_spec will take care of adding company prefix if needed
             indexes.append({'fields': [('history_date', -1)]})
             indexes.append({'fields': [('history_date', -1), ('_auto_id_0', 1)]})
-            indexes.append({'fields': [('_auto_id_0', 1), ('history_date', -1), ('id', -1)]})
+            indexes.append({'fields': [('_auto_id_0', 1), ('history_date', -1), ('_id', -1)]})
 
         return indexes
         

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -893,8 +893,7 @@ class BaseDocument(object):
             # _rippling_process_index_spec will take care of adding company prefix if needed
             indexes.append({'fields': [('history_date', -1)]})
             indexes.append({'fields': [('history_date', -1), ('_auto_id_0', 1)]})
-            indexes.append({'fields': [('_auto_id_0', 1), ('history_date', -1)]})
-            indexes.append({'fields': [('history_date', -1), ('_auto_id_0', -1)]})
+            indexes.append({'fields': [('_auto_id_0', 1), ('history_date', -1), ('id', -1)]})
 
         return indexes
         


### PR DESCRIPTION
the indexes in 896 and 895 may not work if they have been added for the same. Referred: https://docs.mongodb.com/manual/tutorial/sort-results-with-indexes/