### PR TITLE
Parallelize DB dict to ORM conversion

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -834,6 +834,7 @@ class BaseDocument(object):
     def _from_son(cls, son, _auto_dereference=True, only_fields=None, created=False, _lazy_prefetch_base=None,
                   _fields=None, loading_from_db=True):
         """Create an instance of a Document (subclass) from a PyMongo SON.
+        This function should be threadsafe as we call this parallelly from QuerySet
         """
         if not only_fields:
             only_fields = []


### PR DESCRIPTION
An initial cut. Could you please look at the general direction and give your inputs? 

TODO:
- Time taken by the chunkers is still not proportional to their input size. Getting only 2x speed up. Could because of my computer but more probably due to some other bottleneck a little down the stack. I will debug tomorrow.