### PR TITLE
cache SON instead of document in LazyPrefetchBase

### DIFF
--- a/mongoengine/base/proxy.py
+++ b/mongoengine/base/proxy.py
@@ -7,16 +7,86 @@ from contextlib2 import contextmanager
 from collections import defaultdict
 
 
+def _get_field(doc, fields):
+    for index in range(0, len(fields)):
+        if doc is None:
+            return None
+        attname = fields[index].name
+        if not (hasattr(doc, '_data') and attname in doc._data):
+            return None
+        doc = doc._data[attname]
+    return getattr(doc, 'id', None)
+
+
 class LazyPrefetchBase:
     _result_cache = None
+    # mapping from field path to count of refereneces fetched
     _reference_cache_count = None
+    # mapping from field path to map of id -> (data, is_doc) tuple
+    # data is Document object if `is_doc`, else it is SON
     _reference_cache = None
+
+    def _init_reference(self):
+        if self._reference_cache_count is None:
+            self._reference_cache_count = defaultdict(int)
+        if self._reference_cache is None:
+            self._reference_cache = defaultdict(dict)
+
+    def lazy_prefetch_available(self):
+        # make sure we have initialized reference dicts and have data in `_result_cache`
+        return self._reference_cache_count is not None and self._result_cache
+
+    def try_fetch_document(self, value, cls, fields):
+        # tries to fetch document of class `cls` at the path given by `fields` from the reference `value`
+        # returns a tuple (is_valid, data): a bool whether fetched value is valid, and the fetched value
+        field_path = '.'.join([f.name for f in fields])
+        if self._is_prefetched(field_path, value):
+            return (True, self._get_prefetched_document(value, cls, fields, field_path))
+
+        # might have already fetched data for some prefix of `_result_cache`
+        # `_reference_cache_count` stores the number of docs for which data was already fetched
+        start, end = self._reference_cache_count[field_path], len(self._result_cache)
+
+        ids = [_get_field(doc, fields) for doc in self._result_cache[start:end]]
+        ids = [id for id in ids if id is not None]
+
+        # This case usually happens when a queryset cache is not updated, like when cloning a queryset.
+        if value.id not in ids:
+            return (False, None)
+
+        # Fetching is inevitable
+        cursor = cls._get_db()[value.collection].find({"_id": {"$in": ids}})
+        id_son_map = dict((son['_id'], son) for son in cursor)
+
+        self._reference_cache[field_path].update(dict((id, (id_son_map.get(id, None), False)) for id in ids))
+
+        # update `_reference_cache_count` so that we start slice from `end` the next time
+        self._reference_cache_count[field_path] = end
+
+        # we already checked `value.id` is present in `ids`
+        return (True, self._get_prefetched_document(value, cls, fields, field_path))
+
+    def _is_prefetched(self, field_path, value):
+        # checks if data for `value` at `field_path` has already been fetched
+        return value.id in self._reference_cache[field_path]
+
+    def _get_prefetched_document(self, value, cls, fields, field_path):
+        # get the prefetched data as document
+        # only call when `is_prefetched(field_path, id)` is True
+        d = self._reference_cache[field_path]
+        data, is_doc = d[value.id]
+        if data is None or is_doc:
+            return data
+        # else we have SON data. gotta convert it to doc before returning
+        doc = cls._from_son(data, _lazy_prefetch_base=self, _fields=fields)
+        d[value.id] = (doc, True)
+        return doc
+
 
 class ListFieldProxy(list, LazyPrefetchBase):
     def __init__(self, _list):
         self._result_cache = _list
-        self._reference_cache_count = defaultdict(int)
-        self._reference_cache = defaultdict(dict)
+        self._init_reference()
 
 
 class DocumentProxy(lazy_object_proxy.Proxy):

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -25,8 +25,6 @@ class QuerySet(BaseQuerySet, LazyPrefetchBase):
     _has_more = True
     _len = None
     _result_cache = None
-    _reference_cache_count = None
-    _reference_cache = None
 
     def next(self):
         """Wrap the result in a :class:`~mongoengine.Document` object.
@@ -97,10 +95,7 @@ class QuerySet(BaseQuerySet, LazyPrefetchBase):
         Raises StopIteration when there are no more results"""
         if self._result_cache is None:
             self._result_cache = []
-        if self._reference_cache_count is None:
-            self._reference_cache_count = defaultdict(int)
-        if self._reference_cache is None:
-            self._reference_cache = defaultdict(dict)
+        self._init_reference()
 
         pos = 0
         while True:
@@ -120,10 +115,7 @@ class QuerySet(BaseQuerySet, LazyPrefetchBase):
         """
         if self._result_cache is None:
             self._result_cache = []
-        if self._reference_cache_count is None:
-            self._reference_cache_count = defaultdict(int)
-        if self._reference_cache is None:
-            self._reference_cache = defaultdict(dict)
+        self._init_reference()
 
         if self._has_more:
             try:


### PR DESCRIPTION
Avoids document initialization until DocumentProxy triggers a `dereference_dbref`
Note: This only delays initialization on the last field in path. So dereferencing a single `.x.y` still causes initialization of all documents in `.x` path because it is required for getting IDs for `.x.y` path