### PR TITLE
Dont touch company in index if noCompanyPrefix is False

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -1001,9 +1001,6 @@ class BaseDocument(object):
         
     @classmethod
     def _rippling_process_index_spec(cls, spec):
-        # Remove `company` for spec['fields']
-        spec['fields'] = [field for field in spec['fields'] if field[0] != 'company']
-
         if "expireAfterSeconds" in spec:
             args = spec.get("args", {})
             args['noCompanyPrefix'] = True
@@ -1017,6 +1014,8 @@ class BaseDocument(object):
         # Add `company` forcibly to the front.
         noCompanyPrefix = spec.pop('args', {}).get('noCompanyPrefix', False)
         if not noCompanyPrefix and cls._fields.get('company'):
+            # Remove `company` for spec['fields']
+            spec['fields'] = [field for field in spec['fields'] if field[0] != 'company']
             spec['fields'].insert(0, ('company', 1))
             
         return spec


### PR DESCRIPTION
Fixes index for RequestIPTracking.

Definition in code:
```
           {
                'fields': ['requestIP', 'user', 'company', 'createdAt'],
                'partialFilterExpression': {
                    'isDeleted': {'$eq': False}
                },
                'args': {'noCompanyPrefix': True},
            },
```

What gets created today: 
```
hub.security.models.RequestIPTracking has missing indexes [{'partialFilterExpression': {'isDeleted': {'$eq': False}}, 'fields': [('requestIP', 1), ('user', 1), ('createdAt', 1)]}]
dropping index=[(u'company', 1), (u'requestIP', 1), (u'user', 1), (u'createdAt', 1)] for hub.security.models.RequestIPTracking
Ensuring index for hub.security.models.RequestIPTracking
```

Affects InsuranceTask as well.