### PR TITLE
[ ITSEC-1205 ] Added Spoof Context into mongoengine library for Spoof Permissioning

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -16,7 +16,7 @@ from mongoengine.errors import (ValidationError, InvalidDocumentError,
                                 LookUpError, FieldDoesNotExist)
 from mongoengine.python_support import PY3, txt_type
 from mongoengine.base.common import get_document, ALLOW_INHERITANCE
-from mongoengine.common import ReadOnlyContext
+from mongoengine.common import ReadOnlyContext, SpoofContext
 
 from mongoengine.base.datastructures import (
     BaseDict,
@@ -843,7 +843,8 @@ class BaseDocument(object):
         class_alias = cls._meta.get('db_alias', None)
         if class_alias is not None and class_alias in aliases:
             alias = class_alias
-        if ReadOnlyContext.isActive():
+        if ReadOnlyContext.isActive() \
+            or SpoofContext.get_access_level() == 'READ_FULL':
             alias += '_read_only'
         return alias
 

--- a/mongoengine/common.py
+++ b/mongoengine/common.py
@@ -25,6 +25,30 @@ class ReadOnlyContext(object):
     def deactivate(cls):
         ReadOnlyContext.read_only = False
 
+class SpoofContext(object):
+    _access_level = None
+
+    def __init__(self, access_level):
+        self._access_level = access_level
+
+    def __enter__(self):
+        SpoofContext.set_access_level(self._access_level)
+
+    def __exit__(self, *args):
+        SpoofContext.reset()
+
+    @classmethod
+    def get_access_level(cls):
+        return cls._access_level
+
+    @classmethod
+    def set_access_level(cls, access_level):
+        cls._access_level = access_level
+
+    @classmethod
+    def reset(cls):
+        cls._access_level = None
+
 
 def _import_class(cls_name):
     """Cache mechanism for imports.


### PR DESCRIPTION
The following PR does the following:

- Adds spoof context to mongoengine library for spoof permissioning 
- Adds side effect to  _get_db_alias if Spoof Context access level is READ_FULL