### PR TITLE
microoptimization: replace functools.partial with lambda

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1108,17 +1108,12 @@ class ReferenceField(BaseField):
             collection = self.document_type._get_collection_name()
             value = DBRef(collection, self.document_type.id.to_python(value))
         if isinstance(value, DBRef):
+            fields_copy = _fields[:] if _fields is not None else None
             value = DocumentProxy(
-                functools.partial(
-                    dereference_dbref,
-                    value=value,
-                    document_type=self.document_type,
-                    _lazy_prefetch_base=_lazy_prefetch_base,
-                    _fields=_fields[:] if _fields is not None else None,
-                ),
+                lambda: dereference_dbref(value, self.document_type, _lazy_prefetch_base, _fields),
                 value.id,
                 value.collection,
-                lazy_prefetch_base = _lazy_prefetch_base if _fields else None,
+                lazy_prefetch_base=_lazy_prefetch_base if _fields else None
             )
 
         return value
@@ -1228,14 +1223,9 @@ class CachedReferenceField(BaseField):
                 value = DBRef(collection, self.document_type.id.to_python(value['_id']))
 
         if isinstance(value, DBRef):
+            fields_copy = _fields[:] if _fields is not None else None
             value = DocumentProxy(
-                functools.partial(
-                    dereference_dbref,
-                    value=value,
-                    document_type=self.document_type,
-                    _lazy_prefetch_base=_lazy_prefetch_base,
-                    _fields=_fields[:] if _fields is not None else None,
-                ),
+                lambda: dereference_dbref(value, self.document_type, _lazy_prefetch_base, _fields),
                 value.id,
                 value.collection,
                 lazy_prefetch_base = _lazy_prefetch_base if _fields else None


### PR DESCRIPTION
```
%timeit -n 1000 -r 1000 partial(f, x=1, y=2, z=3)
195 ns ± 57 ns per loop (mean ± std. dev. of 1000 runs, 1000 loops each)

%timeit -n 1000 -r 1000 partial(f, 1, 2, 3)
148 ns ± 12.5 ns per loop (mean ± std. dev. of 1000 runs, 1000 loops each)

%timeit -n 1000 -r 1000 (lambda: f(x=1, y=2, z=3))
68.9 ns ± 31.1 ns per loop (mean ± std. dev. of 1000 runs, 1000 loops each)

%timeit -n 1000 -r 1000 (lambda: f(1, 2, 3))
52.5 ns ± 5.53 ns per loop (mean ± std. dev. of 1000 runs, 1000 loops each)

```
nothing crazy but lambda + using positional args instead of kwargs is a mild win in a hotspot.