### PR TITLE
add stub for django-model-changes

### DIFF
--- a/django_model_changes-stubs/__init__.pyi
+++ b/django_model_changes-stubs/__init__.pyi
@@ -1,0 +1,6 @@
+from typing import Any
+
+post_change: Any
+class ChangesMixin(object):
+    def changes(self, **kwargs: Any): ...
+

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ CLASSIFIERS = [
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 
-extra_opts = {"packages": find_packages(exclude=["tests", "tests.*"]) + ['pymongo-stubs', 'bson-stubs', 'django_mongoengine-stubs']}
+extra_opts = {"packages": find_packages(exclude=["tests", "tests.*"]) +\
+        ['pymongo-stubs', 'bson-stubs', 'django_mongoengine-stubs', 'django_model_changes-stubs']}
 if sys.version_info[0] == 3:
     extra_opts['use_2to3'] = True
     extra_opts['tests_require'] = ['nose', 'rednose', 'coverage==3.7.1', 'blinker', 'Pillow>=2.0.0']
@@ -79,6 +80,7 @@ setup(name='mongoengine',
           "pymongo-stubs": ["*.pyi"],
           "bson-stubs": ["*.pyi"],
           "django_mongoengine-stubs": ["*.pyi"],
+          "django_model_changes-stubs": ["*.pyi"],
       },
       include_package_data=True,
       description=DESCRIPTION,


### PR DESCRIPTION
With this, mypy has some understanding of all the bases of RPDocumentBase, and doesn't fallback to any on an unknown attribute access.