### PR TITLE
Make ReadOnlyContext thread-local and make it re-entrant.

### DIFF
--- a/mongoengine/common.py
+++ b/mongoengine/common.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+
+import threading
+
 _class_registry_cache = {}
 _field_list_cache = []
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from unittest import TestCase
+
+from mongoengine.common import ReadOnlyContext
+
+
+class TestReadOnlyContext(TestCase):
+
+    def test_read_only_context(self):
+        self.assertFalse(ReadOnlyContext.isActive())
+        with ReadOnlyContext():
+            self.assertTrue(ReadOnlyContext.isActive())
+            with ReadOnlyContext():
+                self.assertTrue(ReadOnlyContext.isActive())
+            self.assertTrue(ReadOnlyContext.isActive())
+        self.assertFalse(ReadOnlyContext.isActive())


### PR DESCRIPTION
For what it's worth, this is a breaking change so we probably don't want to push it upstream without enabling the old behavior, perhaps by adding class methods `ReadOnlyContext.setGlobal()` and `ReadOnlyContext.setThreadLocal()`. 