### PR TITLE
[INFRA-2106] Type stub patch

### DIFF
--- a/django_mongoengine-stubs/fields.pyi
+++ b/django_mongoengine-stubs/fields.pyi
@@ -1448,7 +1448,7 @@ class ReferenceField(Generic[_ST, _GT], BaseField):
     def __new__(
         cls,
         document_type: Union[Type[_DT], str],
-        blank: Literal[True] = True,
+        blank: Literal[True],
         required: bool = ...,
         help_text: str = ...,
         **kwargs,


### PR DESCRIPTION
Fix overload on ReferenceField. Example error:
```
app/thinkhr_provisioning/api.py:325: error: Item "None" of "Optional[Company]" has no attribute "id"
```

relates to #161 